### PR TITLE
feat(scripts): add skills sync utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,10 +168,10 @@ Progress is checkpointed to `.ritual-build/progress.json` after each phase.
 
 | Harness             | Integration                                                      |
 | ------------------- | ---------------------------------------------------------------- |
-| **Claude Code**     | Drop `skills/` into agent skill path. Native `SKILL.md` format.  |
-| **Cursor**          | Add to `.cursor/rules/` or reference as agent skills             |
-| **OpenClaw**        | Drop `skills/` into agent skill path. Native `SKILL.md` format.  |
-| **Hermes Agent**    | Copy to `skills/blockchain/ritual/` or sync via `skills_sync.py` |
+| **Claude Code**     | `python3 scripts/skills_sync.py --harness claude-code`           |
+| **Cursor**          | `python3 scripts/skills_sync.py --harness cursor`                |
+| **OpenClaw**        | `python3 scripts/skills_sync.py --harness openclaw`              |
+| **Hermes Agent**    | `python3 scripts/skills_sync.py --harness hermes`                |
 | **Codex / ChatGPT** | Point system prompt at `skills/ritual/SKILL.md`                  |
 
 ### Recommended Combinations
@@ -224,6 +224,8 @@ ritual-dapp-skills/
 │   ├── ritual-dapp-longrunning/        # α — Long-running HTTP (0x0805)
 │   ├── ritual-dapp-multimodal/         # α — Image/Audio/Video (0x0818-0x081A)
 │   ├── ritual-dapp-onnx/               # α — ONNX ML inference (0x0800)
+│   ├── ritual-dapp-block-time/         # α — Block time reads
+│   ├── ritual-dapp-da/                 # α — Data availability reads
 │   ├── ritual-dapp-ed25519/            # α — Ed25519 verification (0x0009)
 │   ├── ritual-dapp-scheduler/          # α — Scheduled operations
 │   ├── ritual-dapp-secrets/            # α — Secret management + PII redaction

--- a/scripts/skills_sync.py
+++ b/scripts/skills_sync.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Sync Ritual dApp Skills into agent-specific skill paths.
+
+The README advertises that skills can be synced into Hermes Agent via this
+script (and dropped directly into Claude Code, Cursor, and OpenClaw paths).
+This utility makes that one command.
+
+Supported harnesses:
+  - claude-code   <target>/.claude/skills/ritual-dapp-skills/
+  - cursor        <target>/.cursor/rules/ritual-dapp-skills/
+  - openclaw      <target>/.openclaw/skills/ritual-dapp-skills/
+  - hermes        <target>/skills/blockchain/ritual/
+
+Default target is the user's home directory. Override with --target.
+
+By default this is a non-destructive copy: SKILL.md and any sibling assets
+are read from this repo and written into the harness-specific location,
+preserving subdirectory structure. Existing files are overwritten only when
+their content differs. Re-running is idempotent.
+
+Frontmatter transforms are intentionally NOT applied: the YAML frontmatter
+(`name`, `description`, optional `user_invocable`) is the same across the
+harnesses we support today. A pluggable transform hook is reserved for
+future harnesses with divergent frontmatter requirements.
+
+Usage:
+    # Sync all skills to Claude Code (default harness, default target)
+    python3 scripts/skills_sync.py
+
+    # Sync to Hermes Agent
+    python3 scripts/skills_sync.py --harness hermes
+
+    # Sync to Hermes with a custom target root
+    python3 scripts/skills_sync.py --harness hermes --target ~/dev/hermes
+
+    # Sync only the meta skills (filter by prefix)
+    python3 scripts/skills_sync.py --filter 'ritual-meta-*'
+
+    # Preview what would be written without touching disk
+    python3 scripts/skills_sync.py --harness hermes --dry-run
+
+    # Remove a previous sync (only files this script would have written)
+    python3 scripts/skills_sync.py --harness hermes --uninstall
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import hashlib
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable
+
+# ---------------------------------------------------------------------------
+# Harness registry
+# ---------------------------------------------------------------------------
+
+# Relative subpath inside <target> where this harness expects skill bundles.
+# Add a new harness by appending to this dict; the rest of the script picks
+# it up automatically (CLI choices, target resolution, README docs).
+HARNESS_PATHS: dict[str, str] = {
+    "claude-code": ".claude/skills/ritual-dapp-skills",
+    "cursor": ".cursor/rules/ritual-dapp-skills",
+    "openclaw": ".openclaw/skills/ritual-dapp-skills",
+    "hermes": "skills/blockchain/ritual",
+}
+
+# Hook for future per-harness frontmatter transforms. Current harnesses all
+# accept the upstream SKILL.md frontmatter unmodified, so identity is the
+# safe default. To add a transform: implement `def _transform_<harness>(text)`
+# below and register it here.
+FRONTMATTER_TRANSFORMS: dict[str, Callable[[str], str]] = {
+    "claude-code": lambda s: s,
+    "cursor": lambda s: s,
+    "openclaw": lambda s: s,
+    "hermes": lambda s: s,
+}
+
+DEFAULT_HARNESS = "claude-code"
+
+# Subdirectories under the repo root to sync. Order matters only for
+# readable dry-run output.
+SYNC_DIRS: tuple[str, ...] = ("skills", "agents", "examples", "templates")
+
+
+# ---------------------------------------------------------------------------
+# Filesystem helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FileOp:
+    """A single sync action. `kind` is one of write / skip / remove."""
+
+    kind: str
+    src: Path | None
+    dst: Path
+    reason: str
+
+
+def _repo_root() -> Path:
+    """Resolve the repo root from this script's location.
+
+    `scripts/skills_sync.py` lives one level below the repo root, mirroring
+    the layout of the existing `scripts/pull_contracts.py`.
+    """
+    return Path(__file__).resolve().parent.parent
+
+
+def _file_hash(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _bytes_hash(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _iter_source_files(root: Path, sync_dirs: Iterable[str]) -> Iterable[Path]:
+    for sub in sync_dirs:
+        d = root / sub
+        if not d.exists():
+            continue
+        for p in sorted(d.rglob("*")):
+            if p.is_file() and not _is_ignored(p):
+                yield p
+
+
+def _is_ignored(path: Path) -> bool:
+    """Skip files that should never be synced into agent skill paths."""
+    parts = set(path.parts)
+    if any(seg.startswith(".") for seg in parts if seg not in {".", ".."}):
+        return True
+    if "__pycache__" in parts or "node_modules" in parts:
+        return True
+    if path.suffix in {".pyc", ".pyo"}:
+        return True
+    return False
+
+
+def _filter_matches(rel: Path, patterns: list[str]) -> bool:
+    if not patterns:
+        return True
+    posix = rel.as_posix()
+    # Pattern matches against the top-level skill/agent/example/template name,
+    # OR against the full relative posix path. This lets the user pass either
+    # `ritual-dapp-llm` or `skills/ritual-dapp-llm/SKILL.md`.
+    top_level = rel.parts[1] if len(rel.parts) > 1 else rel.parts[0]
+    return any(
+        fnmatch.fnmatch(posix, pat) or fnmatch.fnmatch(top_level, pat)
+        for pat in patterns
+    )
+
+
+# ---------------------------------------------------------------------------
+# Planning
+# ---------------------------------------------------------------------------
+
+
+def plan_sync(
+    repo: Path,
+    target_root: Path,
+    harness: str,
+    patterns: list[str],
+) -> list[FileOp]:
+    """Build the list of file operations needed to sync, without executing."""
+    if harness not in HARNESS_PATHS:
+        raise ValueError(f"unknown harness: {harness!r}")
+
+    harness_root = target_root / HARNESS_PATHS[harness]
+    transform = FRONTMATTER_TRANSFORMS[harness]
+    ops: list[FileOp] = []
+
+    for src in _iter_source_files(repo, SYNC_DIRS):
+        rel = src.relative_to(repo)
+        if not _filter_matches(rel, patterns):
+            continue
+        dst = harness_root / rel
+        new_bytes = _maybe_transform(src, transform)
+        if dst.exists() and _file_hash(dst) == _bytes_hash(new_bytes):
+            ops.append(FileOp("skip", src, dst, "identical content"))
+        else:
+            reason = "new file" if not dst.exists() else "content differs"
+            ops.append(FileOp("write", src, dst, reason))
+
+    return ops
+
+
+def plan_uninstall(
+    repo: Path,
+    target_root: Path,
+    harness: str,
+) -> list[FileOp]:
+    """List files under the harness root that this script's source tree
+    knows about, plus empty directories left behind."""
+    if harness not in HARNESS_PATHS:
+        raise ValueError(f"unknown harness: {harness!r}")
+
+    harness_root = target_root / HARNESS_PATHS[harness]
+    ops: list[FileOp] = []
+
+    if not harness_root.exists():
+        return ops
+
+    # Files this script could have written: those whose relative path under
+    # harness_root exists under repo as well. This prevents removing user
+    # additions placed under the same directory.
+    known_rel: set[Path] = set()
+    for src in _iter_source_files(repo, SYNC_DIRS):
+        known_rel.add(src.relative_to(repo))
+
+    for dst in sorted(harness_root.rglob("*")):
+        if not dst.is_file():
+            continue
+        rel = dst.relative_to(harness_root)
+        if rel in known_rel:
+            ops.append(FileOp("remove", None, dst, "known-source file"))
+
+    return ops
+
+
+def _maybe_transform(src: Path, transform: Callable[[str], str]) -> bytes:
+    """Apply harness-specific transform if the file is a SKILL.md.
+
+    For everything else (assets, JSON, .py, templates), bytes pass through
+    untouched.
+    """
+    if src.name == "SKILL.md":
+        text = src.read_text(encoding="utf-8")
+        return transform(text).encode("utf-8")
+    return src.read_bytes()
+
+
+# ---------------------------------------------------------------------------
+# Execution
+# ---------------------------------------------------------------------------
+
+
+def apply_ops(ops: list[FileOp], harness: str) -> tuple[int, int]:
+    """Execute a planned op list. Returns (written, removed)."""
+    transform = FRONTMATTER_TRANSFORMS[harness]
+    written = 0
+    removed = 0
+
+    for op in ops:
+        if op.kind == "write":
+            assert op.src is not None
+            op.dst.parent.mkdir(parents=True, exist_ok=True)
+            op.dst.write_bytes(_maybe_transform(op.src, transform))
+            written += 1
+        elif op.kind == "remove":
+            op.dst.unlink()
+            # Walk up and remove any now-empty parent dirs, but stop at
+            # the harness root (which the user owns).
+            parent = op.dst.parent
+            while parent.is_dir() and not any(parent.iterdir()):
+                try:
+                    parent.rmdir()
+                except OSError:
+                    break
+                parent = parent.parent
+            removed += 1
+        # `skip` is a no-op.
+
+    return written, removed
+
+
+def print_plan(
+    all_ops: list[FileOp],
+    visible_ops: list[FileOp],
+    target_root: Path,
+    harness: str,
+) -> None:
+    """Print the plan. Summary counts reflect *all* ops; only `visible_ops`
+    are listed line by line (caller controls verbosity).
+    """
+    counts = {"write": 0, "skip": 0, "remove": 0}
+    for op in all_ops:
+        counts[op.kind] += 1
+
+    print(f"harness:     {harness}")
+    print(f"target root: {target_root}")
+    print(f"sync path:   {target_root / HARNESS_PATHS[harness]}")
+    print()
+    print(
+        f"plan:  write={counts['write']}  "
+        f"skip={counts['skip']}  remove={counts['remove']}"
+    )
+    print()
+
+    for op in visible_ops:
+        if op.kind == "write":
+            marker = "+"
+        elif op.kind == "remove":
+            marker = "-"
+        else:
+            marker = "="
+        rel = op.dst
+        try:
+            rel = op.dst.relative_to(target_root)
+        except ValueError:
+            pass
+        print(f"  {marker} {rel}  ({op.reason})")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--harness",
+        choices=sorted(HARNESS_PATHS),
+        default=DEFAULT_HARNESS,
+        help=f"target harness (default: {DEFAULT_HARNESS})",
+    )
+    parser.add_argument(
+        "--target",
+        type=Path,
+        default=Path.home(),
+        help="root under which the harness-specific subpath is created "
+        "(default: $HOME)",
+    )
+    parser.add_argument(
+        "--filter",
+        action="append",
+        default=[],
+        metavar="PATTERN",
+        help="only sync skills/agents/examples matching this fnmatch "
+        "pattern; may be passed multiple times (e.g. 'ritual-meta-*' or "
+        "'skills/ritual-dapp-llm/*')",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print planned writes without touching disk",
+    )
+    parser.add_argument(
+        "--uninstall",
+        action="store_true",
+        help="remove previously synced files (only files known to this repo)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="include skipped files in the plan output",
+    )
+    args = parser.parse_args(argv)
+
+    repo = _repo_root()
+    target = args.target.expanduser().resolve()
+
+    if args.uninstall:
+        ops = plan_uninstall(repo, target, args.harness)
+        action = "uninstall"
+    else:
+        ops = plan_sync(repo, target, args.harness, args.filter)
+        action = "sync"
+
+    # Filter skips out of the printed lines unless --verbose. Summary still
+    # reflects all ops.
+    visible_ops = ops if args.verbose else [o for o in ops if o.kind != "skip"]
+    print_plan(ops, visible_ops, target, args.harness)
+
+    if args.dry_run:
+        print()
+        print("dry-run: no changes written")
+        return 0
+
+    if not ops or all(o.kind == "skip" for o in ops):
+        print()
+        print(f"{action}: nothing to do")
+        return 0
+
+    written, removed = apply_ops(ops, args.harness)
+    print()
+    print(f"{action}: wrote {written} file(s), removed {removed} file(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/skills_sync.py
+++ b/scripts/skills_sync.py
@@ -96,6 +96,7 @@ class FileOp:
 
     kind: str
     src: Path | None
+    root: Path
     dst: Path
     reason: str
 
@@ -179,10 +180,10 @@ def plan_sync(
         dst = harness_root / rel
         new_bytes = _maybe_transform(src, transform)
         if dst.exists() and _file_hash(dst) == _bytes_hash(new_bytes):
-            ops.append(FileOp("skip", src, dst, "identical content"))
+            ops.append(FileOp("skip", src, harness_root, dst, "identical content"))
         else:
             reason = "new file" if not dst.exists() else "content differs"
-            ops.append(FileOp("write", src, dst, reason))
+            ops.append(FileOp("write", src, harness_root, dst, reason))
 
     return ops
 
@@ -215,7 +216,7 @@ def plan_uninstall(
             continue
         rel = dst.relative_to(harness_root)
         if rel in known_rel:
-            ops.append(FileOp("remove", None, dst, "known-source file"))
+            ops.append(FileOp("remove", None, harness_root, dst, "known-source file"))
 
     return ops
 
@@ -251,10 +252,10 @@ def apply_ops(ops: list[FileOp], harness: str) -> tuple[int, int]:
             written += 1
         elif op.kind == "remove":
             op.dst.unlink()
-            # Walk up and remove any now-empty parent dirs, but stop at
-            # the harness root (which the user owns).
+            # Walk up and remove any now-empty parent dirs, but never remove
+            # the harness root itself.
             parent = op.dst.parent
-            while parent.is_dir() and not any(parent.iterdir()):
+            while parent != op.root and parent.is_dir() and not any(parent.iterdir()):
                 try:
                     parent.rmdir()
                 except OSError:

--- a/scripts/skills_sync.py
+++ b/scripts/skills_sync.py
@@ -6,10 +6,10 @@ script (and dropped directly into Claude Code, Cursor, and OpenClaw paths).
 This utility makes that one command.
 
 Supported harnesses:
-  - claude-code   <target>/.claude/skills/ritual-dapp-skills/
-  - cursor        <target>/.cursor/rules/ritual-dapp-skills/
-  - openclaw      <target>/.openclaw/skills/ritual-dapp-skills/
-  - hermes        <target>/skills/blockchain/ritual/
+  - claude-code  -> <target>/.claude/skills/ritual-dapp-skills/
+  - cursor       -> <target>/.cursor/rules/ritual-dapp-skills/
+  - openclaw     -> <target>/.openclaw/skills/ritual-dapp-skills/
+  - hermes       -> <target>/skills/blockchain/ritual/
 
 Default target is the user's home directory. Override with --target.
 

--- a/scripts/test_skills_sync.py
+++ b/scripts/test_skills_sync.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Tests for scripts/skills_sync.py.
+
+Uses stdlib unittest + tmp_path fixtures; no third-party dependencies.
+
+Run with:
+    python3 scripts/test_skills_sync.py
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+# Import target. The script sits next to this test file.
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import skills_sync as ss  # noqa: E402
+
+
+def _make_fixture_repo(root: Path) -> None:
+    """Build a minimal fixture mirroring the real repo layout."""
+    (root / "scripts").mkdir()
+    (root / "scripts" / "skills_sync.py").write_text("# placeholder\n")
+
+    # Two skills, one with sibling assets.
+    (root / "skills" / "ritual-dapp-llm").mkdir(parents=True)
+    (root / "skills" / "ritual-dapp-llm" / "SKILL.md").write_text(
+        "---\nname: ritual-dapp-llm\ndescription: LLM patterns.\n---\n\nbody\n"
+    )
+    (root / "skills" / "ritual-dapp-llm" / "examples.md").write_text(
+        "# Examples\n"
+    )
+
+    (root / "skills" / "ritual-meta-bootstrap").mkdir(parents=True)
+    (root / "skills" / "ritual-meta-bootstrap" / "SKILL.md").write_text(
+        "---\nname: ritual-meta-bootstrap\ndescription: Meta.\n---\n\nbody\n"
+    )
+
+    # One agent.
+    (root / "agents").mkdir()
+    (root / "agents" / "ritual-dapp-builder.md").write_text("# Builder\n")
+
+    # One template.
+    (root / "templates" / "starter").mkdir(parents=True)
+    (root / "templates" / "starter" / "index.js").write_text("'use strict';\n")
+
+    # Noise that must be ignored.
+    (root / "skills" / "ritual-dapp-llm" / ".DS_Store").write_text("noise")
+    (root / "skills" / "ritual-dapp-llm" / "__pycache__").mkdir()
+    (root / "skills" / "ritual-dapp-llm" / "__pycache__" / "x.pyc").write_text(
+        "noise"
+    )
+
+
+class TestSkillsSync(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="ritual_sync_test_")
+        self.tmp = Path(self._tmp)
+        self.repo = self.tmp / "repo"
+        self.target = self.tmp / "target"
+        self.repo.mkdir()
+        self.target.mkdir()
+        _make_fixture_repo(self.repo)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    # ------------------------------------------------------------------ tests
+
+    def test_harnesses_registered_consistently(self) -> None:
+        self.assertEqual(
+            set(ss.HARNESS_PATHS),
+            set(ss.FRONTMATTER_TRANSFORMS),
+            "every harness needs a frontmatter transform entry",
+        )
+
+    def test_plan_lists_all_real_files_for_default_harness(self) -> None:
+        ops = ss.plan_sync(self.repo, self.target, "claude-code", patterns=[])
+        writes = [o for o in ops if o.kind == "write"]
+        self.assertEqual(
+            len(writes),
+            5,  # 2 SKILL.md + 1 examples.md + 1 agent + 1 template
+            f"unexpected plan: {[str(o.dst) for o in writes]}",
+        )
+
+    def test_ignored_files_excluded(self) -> None:
+        ops = ss.plan_sync(self.repo, self.target, "hermes", patterns=[])
+        for op in ops:
+            self.assertNotIn(".DS_Store", op.dst.name)
+            self.assertNotIn("__pycache__", op.dst.parts)
+            self.assertFalse(op.dst.name.endswith(".pyc"))
+
+    def test_apply_then_replan_is_idempotent(self) -> None:
+        ops1 = ss.plan_sync(self.repo, self.target, "hermes", patterns=[])
+        ss.apply_ops(ops1, "hermes")
+        ops2 = ss.plan_sync(self.repo, self.target, "hermes", patterns=[])
+        for op in ops2:
+            self.assertEqual(
+                op.kind, "skip", f"unexpected non-skip on re-run: {op}"
+            )
+
+    def test_modified_file_re_synced(self) -> None:
+        ss.apply_ops(
+            ss.plan_sync(self.repo, self.target, "hermes", []), "hermes"
+        )
+        skill = self.repo / "skills" / "ritual-meta-bootstrap" / "SKILL.md"
+        skill.write_text(skill.read_text() + "\nEDITED\n")
+        ops = ss.plan_sync(self.repo, self.target, "hermes", patterns=[])
+        writes = [o for o in ops if o.kind == "write"]
+        self.assertEqual(len(writes), 1)
+        self.assertTrue(writes[0].dst.name == "SKILL.md")
+
+    def test_harness_path_layout(self) -> None:
+        ops = ss.plan_sync(self.repo, self.target, "hermes", patterns=[])
+        ss.apply_ops(ops, "hermes")
+        expected = self.target / "skills" / "blockchain" / "ritual"
+        self.assertTrue(expected.is_dir())
+        # And no Claude-Code path was created.
+        self.assertFalse((self.target / ".claude").exists())
+
+    def test_filter_matches_top_level_skill_name(self) -> None:
+        ops = ss.plan_sync(
+            self.repo, self.target, "hermes", patterns=["ritual-meta-*"]
+        )
+        # Only the meta skill should match. Agents/templates use different
+        # top-level names and should be excluded.
+        for op in ops:
+            self.assertIn("ritual-meta-bootstrap", op.dst.parts)
+
+    def test_filter_matches_relative_glob(self) -> None:
+        ops = ss.plan_sync(
+            self.repo, self.target, "hermes", patterns=["agents/*"]
+        )
+        self.assertEqual(len(ops), 1)
+        self.assertEqual(ops[0].dst.name, "ritual-dapp-builder.md")
+
+    def test_uninstall_removes_only_known_files(self) -> None:
+        # Sync, then add a user-authored file in the harness root.
+        ss.apply_ops(
+            ss.plan_sync(self.repo, self.target, "hermes", []), "hermes"
+        )
+        user_file = (
+            self.target / "skills" / "blockchain" / "ritual" / "USER_NOTES.md"
+        )
+        user_file.write_text("my notes\n")
+
+        ops = ss.plan_uninstall(self.repo, self.target, "hermes")
+        ss.apply_ops(ops, "hermes")
+
+        self.assertTrue(user_file.exists(), "user file must be preserved")
+        # All known sources gone.
+        self.assertFalse(
+            (
+                self.target
+                / "skills"
+                / "blockchain"
+                / "ritual"
+                / "skills"
+                / "ritual-meta-bootstrap"
+                / "SKILL.md"
+            ).exists()
+        )
+
+    def test_uninstall_on_missing_target_noop(self) -> None:
+        ops = ss.plan_uninstall(self.repo, self.tmp / "nonexistent", "hermes")
+        self.assertEqual(ops, [])
+
+    def test_unknown_harness_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            ss.plan_sync(self.repo, self.target, "made-up", patterns=[])
+
+    def test_dry_run_writes_nothing(self) -> None:
+        from unittest.mock import patch
+
+        with patch.object(ss, "_repo_root", return_value=self.repo):
+            rc = ss.main(
+                [
+                    "--harness",
+                    "hermes",
+                    "--target",
+                    str(self.target),
+                    "--dry-run",
+                ]
+            )
+        self.assertEqual(rc, 0)
+        self.assertFalse((self.target / "skills" / "blockchain").exists())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/test_skills_sync.py
+++ b/scripts/test_skills_sync.py
@@ -165,6 +165,18 @@ class TestSkillsSync(unittest.TestCase):
             ).exists()
         )
 
+    def test_uninstall_preserves_harness_root_directory(self) -> None:
+        ss.apply_ops(
+            ss.plan_sync(self.repo, self.target, "hermes", []), "hermes"
+        )
+        harness_root = self.target / "skills" / "blockchain" / "ritual"
+
+        ops = ss.plan_uninstall(self.repo, self.target, "hermes")
+        ss.apply_ops(ops, "hermes")
+
+        self.assertTrue(harness_root.is_dir())
+        self.assertEqual(list(harness_root.iterdir()), [])
+
     def test_uninstall_on_missing_target_noop(self) -> None:
         ops = ss.plan_uninstall(self.repo, self.tmp / "nonexistent", "hermes")
         self.assertEqual(ops, [])


### PR DESCRIPTION
## Summary

Adds `scripts/skills_sync.py`, which the README already references for Hermes but which does not currently exist in the repository. Also updates `README.md` so the harness install table points at concrete sync commands, and refreshes the directory tree to include the current `ritual-dapp-block-time` and `ritual-dapp-da` skills.

## Validation

- `python3 -m py_compile scripts/skills_sync.py scripts/test_skills_sync.py`
- `python3 scripts/test_skills_sync.py`
- `python3 scripts/skills_sync.py --harness hermes --target /tmp/ritual-sync-smoke --dry-run`

Observed real-repo dry-run: `plan:  write=49  skip=0  remove=0`.
