### PR TITLE
Fix: Apply strict dependency pinning, SRI digests, and HTTP security headers to frontend assets

### DIFF
--- a/site/firebase.json
+++ b/site/firebase.json
@@ -10,13 +10,13 @@
       "**/.*",
       "**/node_modules/**"
     ],
-        "headers": [
+    "headers": [
       {
         "source": "**",
         "headers": [
           {
             "key": "Content-Security-Policy",
-            "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; img-src 'self' data: https://skills.ritualfoundation.org https://explorer.ritualfoundation.org; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://esm.sh; connect-src 'self'; frame-src https://explorer.ritualfoundation.org; worker-src 'self' blob:; upgrade-insecure-requests"
+            "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; img-src 'self' data: https://skills.ritualfoundation.org https://explorer.ritualfoundation.org; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://esm.sh https://cdn.esm.sh; connect-src 'self'; frame-src https://explorer.ritualfoundation.org; worker-src 'self' blob:; upgrade-insecure-requests"
           },
           {
             "key": "X-Content-Type-Options",
@@ -38,7 +38,6 @@
       },
       {
         "source": "/",
-
         "headers": [
           {
             "key": "Cache-Control",

--- a/site/firebase.json
+++ b/site/firebase.json
@@ -10,9 +10,35 @@
       "**/.*",
       "**/node_modules/**"
     ],
-    "headers": [
+        "headers": [
+      {
+        "source": "**",
+        "headers": [
+          {
+            "key": "Content-Security-Policy",
+            "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; img-src 'self' data: https://skills.ritualfoundation.org https://explorer.ritualfoundation.org; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://esm.sh; connect-src 'self'; frame-src https://explorer.ritualfoundation.org; worker-src 'self' blob:; upgrade-insecure-requests"
+          },
+          {
+            "key": "X-Content-Type-Options",
+            "value": "nosniff"
+          },
+          {
+            "key": "Referrer-Policy",
+            "value": "strict-origin-when-cross-origin"
+          },
+          {
+            "key": "Permissions-Policy",
+            "value": "camera=(), microphone=(), geolocation=()"
+          },
+          {
+            "key": "X-Frame-Options",
+            "value": "SAMEORIGIN"
+          }
+        ]
+      },
       {
         "source": "/",
+
         "headers": [
           {
             "key": "Cache-Control",

--- a/site/index.html
+++ b/site/index.html
@@ -957,7 +957,7 @@ footer a { color: var(--accent); }
     <a href="#skills">Skills</a>
     <a href="#architecture">Architecture</a>
     <a href="#chain">Chain</a>
-    <a href="https://github.com/ritual-foundation/ritual-dapp-skills" target="_blank">GitHub</a>
+    <a href="https://github.com/ritual-foundation/ritual-dapp-skills" target="_blank" rel="noopener noreferrer">GitHub</a>
   </div>
 </nav>
 
@@ -1387,37 +1387,37 @@ footer a { color: var(--accent); }
   <div class="ref-grid">
     <div class="ref-item">
       <div class="ref-label">RitualWallet</div>
-      <div class="ref-value"><a href="https://explorer.ritualfoundation.org/address/0x532F0dF0896F353d8C3DD8cc134e8129DA2a3948" target="_blank">0x532F0dF0896F353d8C3DD8cc134e8129DA2a3948</a></div>
+      <div class="ref-value"><a href="https://explorer.ritualfoundation.org/address/0x532F0dF0896F353d8C3DD8cc134e8129DA2a3948" target="_blank" rel="noopener noreferrer">0x532F0dF0896F353d8C3DD8cc134e8129DA2a3948</a></div>
     </div>
     <div class="ref-item">
       <div class="ref-label">AsyncJobTracker</div>
-      <div class="ref-value"><a href="https://explorer.ritualfoundation.org/address/0xC069FFCa0389f44eCA2C626e55491b0ab045AEF5" target="_blank">0xC069FFCa0389f44eCA2C626e55491b0ab045AEF5</a></div>
+      <div class="ref-value"><a href="https://explorer.ritualfoundation.org/address/0xC069FFCa0389f44eCA2C626e55491b0ab045AEF5" target="_blank" rel="noopener noreferrer">0xC069FFCa0389f44eCA2C626e55491b0ab045AEF5</a></div>
     </div>
     <div class="ref-item">
       <div class="ref-label">TEEServiceRegistry</div>
-      <div class="ref-value"><a href="https://explorer.ritualfoundation.org/address/0x9644e8562cE0Fe12b4deeC4163c064A8862Bf47F" target="_blank">0x9644e8562cE0Fe12b4deeC4163c064A8862Bf47F</a></div>
+      <div class="ref-value"><a href="https://explorer.ritualfoundation.org/address/0x9644e8562cE0Fe12b4deeC4163c064A8862Bf47F" target="_blank" rel="noopener noreferrer">0x9644e8562cE0Fe12b4deeC4163c064A8862Bf47F</a></div>
     </div>
     <div class="ref-item">
       <div class="ref-label">Scheduler</div>
-      <div class="ref-value"><a href="https://explorer.ritualfoundation.org/address/0x56e776BAE2DD60664b69Bd5F865F1180ffB7D58B" target="_blank">0x56e776BAE2DD60664b69Bd5F865F1180ffB7D58B</a></div>
+      <div class="ref-value"><a href="https://explorer.ritualfoundation.org/address/0x56e776BAE2DD60664b69Bd5F865F1180ffB7D58B" target="_blank" rel="noopener noreferrer">0x56e776BAE2DD60664b69Bd5F865F1180ffB7D58B</a></div>
     </div>
     <div class="ref-item">
       <div class="ref-label">SecretsACL</div>
-      <div class="ref-value"><a href="https://explorer.ritualfoundation.org/address/0xf9BF1BC8A3e79B9EBeD0fa2Db70D0513fecE32FD" target="_blank">0xf9BF1BC8A3e79B9EBeD0fa2Db70D0513fecE32FD</a></div>
+      <div class="ref-value"><a href="https://explorer.ritualfoundation.org/address/0xf9BF1BC8A3e79B9EBeD0fa2Db70D0513fecE32FD" target="_blank" rel="noopener noreferrer">0xf9BF1BC8A3e79B9EBeD0fa2Db70D0513fecE32FD</a></div>
     </div>
     <div class="ref-item">
       <div class="ref-label">AsyncDelivery</div>
-      <div class="ref-value"><a href="https://explorer.ritualfoundation.org/address/0x5A16214fF555848411544b005f7Ac063742f39F6" target="_blank">0x5A16214fF555848411544b005f7Ac063742f39F6</a></div>
+      <div class="ref-value"><a href="https://explorer.ritualfoundation.org/address/0x5A16214fF555848411544b005f7Ac063742f39F6" target="_blank" rel="noopener noreferrer">0x5A16214fF555848411544b005f7Ac063742f39F6</a></div>
     </div>
   </div>
 </section>
 
 <!-- Block Explorer -->
 <section style="padding:80px 32px 120px;max-width:1164px;margin:0 auto;" id="explorer">
-  <h2 style="font-size:32px;font-weight:600;letter-spacing:-1px;margin-bottom:24px;"><a href="https://explorer.ritualfoundation.org/" target="_blank" style="color:var(--text);text-decoration:none;transition:text-shadow 0.3s;">Block Explorer</a></h2>
+  <h2 style="font-size:32px;font-weight:600;letter-spacing:-1px;margin-bottom:24px;"><a href="https://explorer.ritualfoundation.org/" target="_blank" rel="noopener noreferrer" style="color:var(--text);text-decoration:none;transition:text-shadow 0.3s;">Block Explorer</a></h2>
   <div class="explorer-frame" style="border-radius:12px;overflow:hidden;border:1px solid var(--border-subtle);height:700px;position:relative;transition:border-color 0.3s;max-width:1000px;margin:0 auto;">
     <iframe src="https://explorer.ritualfoundation.org/" style="width:100%;height:calc(100% + 80px);border:none;margin-top:-80px;" loading="lazy" sandbox="allow-scripts allow-same-origin allow-popups" title="Ritual Block Explorer"></iframe>
-    <a href="https://explorer.ritualfoundation.org/" target="_blank" style="position:absolute;top:12px;right:12px;padding:6px 14px;border-radius:6px;background:rgba(9,9,11,0.85);border:1px solid var(--border);color:var(--accent);font-family:var(--font-mono);font-size:11px;text-decoration:none;transition:color 0.2s,border-color 0.2s,box-shadow 0.2s;backdrop-filter:blur(8px);z-index:2;border-color:var(--accent);">Open ↗</a>
+    <a href="https://explorer.ritualfoundation.org/" target="_blank" rel="noopener noreferrer" style="position:absolute;top:12px;right:12px;padding:6px 14px;border-radius:6px;background:rgba(9,9,11,0.85);border:1px solid var(--border);color:var(--accent);font-family:var(--font-mono);font-size:11px;text-decoration:none;transition:color 0.2s,border-color 0.2s,box-shadow 0.2s;backdrop-filter:blur(8px);z-index:2;border-color:var(--accent);">Open ↗</a>
   </div>
 </section>
 
@@ -1600,7 +1600,7 @@ const SKILLS = {
     {name:"Scheduler",addr:"0x56e7…D58B",desc:"Block-based delayed and recurring on-chain execution",
      detail:`<h3>What it teaches</h3><p>How to use the Scheduler contract (<code>0x56e776BAE2DD60664b69Bd5F865F1180ffB7D58B</code>) to schedule delayed and recurring precompile calls on Ritual Chain. Execution is block-based, not time-based.</p><h3>Key patterns</h3><ul><li><code>setTimeout</code> / <code>setInterval</code> for Solidity: delayed and recurring on-chain calls</li><li>FSM: SCHEDULED → EXECUTING → COMPLETED/FAILED</li><li>Uses <code>TxScheduled</code> (type 0x10) system tx from sender <code>0x0000...00fa7e</code></li><li>Predicates for conditional execution (only run when a condition is true)</li><li>RitualWallet must be funded before each execution (just-in-time deposits supported)</li></ul>`,exec:''},
     {name:"Secrets",addr:"",desc:"ECIES encryption, secret string replacement, delegated access control",
-     detail:`<h3>What it teaches</h3><p>Secret management for Ritual precompiles.</p><h3>Key patterns</h3><ul><li>ECIES encryption to executor public key</li><li><code>SECRET</code> string replacement in precompile inputs</li><li>Private outputs via <code>userPublicKey</code> field</li><li><a href="https://explorer.ritualfoundation.org/address/0xf9BF1BC8A3e79B9EBeD0fa2Db70D0513fecE32FD" target="_blank">SecretsAccessControl</a> for delegated access</li><li>Contract-owned vs EOA-owned secrets with different <code>msg.sender</code> rules</li></ul>`,exec:''},
+     detail:`<h3>What it teaches</h3><p>Secret management for Ritual precompiles.</p><h3>Key patterns</h3><ul><li>ECIES encryption to executor public key</li><li><code>SECRET</code> string replacement in precompile inputs</li><li>Private outputs via <code>userPublicKey</code> field</li><li><a href="https://explorer.ritualfoundation.org/address/0xf9BF1BC8A3e79B9EBeD0fa2Db70D0513fecE32FD" target="_blank" rel="noopener noreferrer">SecretsAccessControl</a> for delegated access</li><li>Contract-owned vs EOA-owned secrets with different <code>msg.sender</code> rules</li></ul>`,exec:''},
     {name:"X402 Payments",addr:"via 0x0801 / 0x0805",desc:"Micropayments for paid API access",
      detail:`<h3>What it teaches</h3><p>X402 micropayment protocol for paid APIs via the HTTP and Long-Running HTTP precompiles.</p><h3>Key patterns</h3><ul><li>ECIES-encrypted payment credentials</li><li>Budget management per API call</li><li>Shared credential patterns</li><li>Flows through HTTP (0x0801) and Long-Running HTTP (0x0805), not a separate precompile</li></ul>`,exec:''},
     {name:"Passkey / WebAuthn",addr:"",desc:"Sign transactions with Face ID, fingerprint, or hardware keys",
@@ -1687,7 +1687,7 @@ function copyCode(blockId) {
 }
 </script>
 <!-- GSAP (animations only) -->
-<script src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js" integrity="sha384-g4NTh/Iv5PPU4xPyhEWqPcwtNXOvdaDI8LLnyYfyNZOjKJeYQyjzQ9X5275eBjpt" crossorigin="anonymous"></script>
 <script>
 var fpGo, exitSlideMode;
 

--- a/templates/nextjs-starter/package.json.tmpl
+++ b/templates/nextjs-starter/package.json.tmpl
@@ -19,7 +19,7 @@
   },
 
   "devDependencies": {
-    "typescript": "5.6.0",
+    "typescript": "5.6.2",
     "@types/react": "18.3.0",
     "tailwindcss": "3.4.0",
     "autoprefixer": "10.4.0",

--- a/templates/nextjs-starter/package.json.tmpl
+++ b/templates/nextjs-starter/package.json.tmpl
@@ -8,20 +8,21 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "^14.2.0",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "wagmi": "^2.12.0",
-    "viem": "^2.21.0",
-    "eciesjs": "^0.4.15",
-    "@tanstack/react-query": "^5.59.0",
-    "zustand": "^4.5.0"
+    "next": "14.2.0",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "wagmi": "2.12.0",
+    "viem": "2.21.0",
+    "eciesjs": "0.4.15",
+    "@tanstack/react-query": "5.59.0",
+    "zustand": "4.5.0"
   },
+
   "devDependencies": {
-    "typescript": "^5.6.0",
-    "@types/react": "^18.3.0",
-    "tailwindcss": "^3.4.0",
-    "autoprefixer": "^10.4.0",
-    "postcss": "^8.4.0"
+    "typescript": "5.6.0",
+    "@types/react": "18.3.0",
+    "tailwindcss": "3.4.0",
+    "autoprefixer": "10.4.0",
+    "postcss": "8.4.0"
   }
 }


### PR DESCRIPTION
This PR addresses frontend security, static site delivery, and template reproducibility issues identified in the workspace-wide security audit.

**Vulnerabilities & Reliability Defects Remediated:**
* **Dependency Pinning (`templates/nextjs-starter/package.json.tmpl`):** Removed caret (`^`) selectors from all direct dependency ranges. Dependencies are now strictly pinned to ensure generated starters are perfectly reproducible without requiring a lockfile.
* **External Link & Asset Security (`site/index.html`):** Added the `rel="noopener noreferrer"` policy to all `_blank` external links to prevent tab-nabbing. Enforced Subresource Integrity (SRI) by adding a verified SHA-384 digest and `crossorigin="anonymous"` attribute to the pinned GSAP CDN asset.
* **HTTP Security Headers (`site/firebase.json`):** Hardened the public static site by introducing baseline security response headers. Added a strict Content-Security-Policy (CSP) covering inline scripts, Google Fonts, pinned CDN assets, and the explorer iframe. Additionally implemented MIME-sniffing protection (`nosniff`), strict referrer policies, same-origin framing policies, and capability-restricting permissions policies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CSP and framing rules can break the live site if any script or resource loads from an origin not in the policy; otherwise changes are defensive hardening and template pinning with no auth or data-path impact.
> 
> **Overview**
> Hardens the **skills static site** and **Next.js starter template** from audit findings.
> 
> **Firebase hosting** now sends global response headers on all assets: a **Content-Security-Policy** aligned with inline scripts, Google Fonts, jsdelivr/esm.sh CDNs, and the embedded explorer iframe, plus **nosniff**, **Referrer-Policy**, **Permissions-Policy**, and **X-Frame-Options: SAMEORIGIN**.
> 
> **`site/index.html`** adds **`rel="noopener noreferrer"`** on every `target="_blank"` link (GitHub, explorer, contract addresses, modal copy) and **Subresource Integrity** with **`crossorigin="anonymous"`** on the pinned GSAP 3.12.5 script.
> 
> **`templates/nextjs-starter/package.json.tmpl`** drops caret ranges so generated apps install **exact** dependency versions without relying on a lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b85d20792a87d1e4a47efa87ce8865cacf3af6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->